### PR TITLE
Fix setuptools/numpy installation issue in Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.24.4
+numpy==1.26.4
 requests==2.32.3
 sentencepiece==0.2.0
 tensorboard==2.14.0


### PR DESCRIPTION
This bumps numpy to a minor newer version that includes the fix to this issue: 

https://github.com/pypa/setuptools/issues/3935 
https://github.com/numpy/numpy/issues/23808

I gave it a quick try (training and sampling) and seems to work for me, but you might want to test it on older versions of python too :) 

This should be the latest release on the 1.x branch of numpy.